### PR TITLE
Update db2.yml (SLES)

### DIFF
--- a/sles/db2.yml
+++ b/sles/db2.yml
@@ -52,7 +52,7 @@
   become: yes
 
 - name: Install DB2 Client
-  shell: /opt/ibm/client/db2setup -r /opt/ibm/client/db2.linux.rsp
+  shell: /opt/ibm/client/db2setup -r /opt/ibm/client/db2.linux.rsp -f sysreq
 
 - name: Set DB2 Environment
   copy:


### PR DESCRIPTION
Added "-f sysreq" option to db2setup command to avoid "Requirement not matched for DB2 database" error.